### PR TITLE
Teleport: mirror the port labels of the ports being teleported.

### DIFF
--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -403,7 +403,7 @@ struct TeleportInModuleWidget : TeleportModuleWidget {
 					}
 				}
 				if (! foundLabel) {
-					inModule->setPortLabel(i, string::f("Port %d not connected", i));
+					inModule->setPortLabel(i, string::f("Port %d not connected", i + 1));
 				}
 			}
 		}

--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -85,7 +85,7 @@ struct TeleportInModule : Teleport {
 								std::string modelName = srcModule->getModel()->name;
 								PortInfo *portInfo = srcModule->outputInfos[cable->outputId];
 								if (portInfo) {
-									setPortLabel(i, string::f("%s - %s", modelName.c_str(), portInfo->getName().c_str()));
+									configInput(i, string::f("%s - %s", modelName.c_str(), portInfo->getName().c_str()));
 									foundLabel = true;
 								}
 							}
@@ -94,7 +94,7 @@ struct TeleportInModule : Teleport {
 				}
 			}
 			if (! foundLabel) {
-				setPortLabel(i, string::f("Port %d not connected", i + 1));
+				configInput(i, string::f("Port %d not connected", i + 1));
 			}
 		}
 	}

--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -406,8 +406,10 @@ struct TeleportInModuleWidget : TeleportModuleWidget {
 		addLabelDisplay(new EditableTeleportLabelTextbox(module));
 		for(int i = 0; i < NUM_TELEPORT_INPUTS; i++) {
 			PortWidget *jack = createInputCentered<PJ301MPort>(Vec(22.5, getPortYCoord(i)), module, TeleportInModule::INPUT_1 + i);
-			addInput(jack);
-			module->setPortWidget(i, jack);
+			if (module) {
+				addInput(jack);
+				module->setPortWidget(i, jack);
+			}
 		}
 	}
 };
@@ -424,8 +426,10 @@ struct TeleportOutModuleWidget : TeleportModuleWidget {
 		for(int i = 0; i < NUM_TELEPORT_INPUTS; i++) {
 			float y = getPortYCoord(i);
 			PortWidget *jack = createOutputCentered<PJ301MPort>(Vec(22.5, y), module, TeleportOutModule::OUTPUT_1 + i);
-			addOutput(jack);
-			module->setPortWidget(i, jack);
+			if (module) {
+				addOutput(jack);
+				module->setPortWidget(i, jack);
+			}
 			addChild(createTinyLightForPort<GreenRedLight>(Vec(22.5, y), module, TeleportOutModule::OUTPUT_1_LIGHTG + 2*i));
 		}
 	}

--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -72,9 +72,9 @@ struct TeleportInModule : Teleport {
 
 	void processPortLabels() {
 		for (int i = 0; i < NUM_TELEPORT_INPUTS; i++) {
+			bool foundLabel = false;
 			if (portWidgets[i]) {
 				std::vector<CableWidget*> cables = APP->scene->rack->getCablesOnPort(portWidgets[i]);
-				bool foundLabel = false;
 				if (cables.size()) {
 					CableWidget *cw = cables.front();
 					if (cw) {
@@ -92,9 +92,9 @@ struct TeleportInModule : Teleport {
 						}
 					}
 				}
-				if (! foundLabel) {
-					setPortLabel(i, string::f("Port %d not connected", i + 1));
-				}
+			}
+			if (! foundLabel) {
+				setPortLabel(i, string::f("Port %d not connected", i + 1));
 			}
 		}
 	}

--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -54,7 +54,7 @@ struct TeleportInModule : Teleport {
 	TeleportInModule() : Teleport(NUM_PARAMS, NUM_INPUTS, NUM_OUTPUTS, NUM_LIGHTS) {
 		assert(NUM_INPUTS == NUM_TELEPORT_INPUTS);
 		for(int i = 0; i < NUM_TELEPORT_INPUTS; i++) {
-			configInput(i, string::f("Port %d", i + 1));
+			configInput(i, string::f("Port %d not connected", i + 1));
 		}
 		label = getLabel();
 		addSource(this);
@@ -158,7 +158,7 @@ struct TeleportOutModule : Teleport {
 
 	void reconfigurePorts() {
 		for(int i = 0; i < NUM_TELEPORT_INPUTS; i++) {
-			configOutput(i, string::f("Port %d", i + 1));
+			configOutput(i, string::f("Port %d not connected", i + 1));
 		}
 	}
 
@@ -172,9 +172,9 @@ struct TeleportOutModule : Teleport {
 					PortInfo *portInfo = src->inputInfos[TeleportInModule::INPUT_1 + i];
 					if (portInfo) {
 						std::string portName = portInfo->name;
-						configOutput(i, portName.c_str());
+						configOutput(i, portName);
 					} else {
-						configOutput(i, string::f("Port %d", i));
+						configOutput(i, string::f("Port %d not connected", i));
 					}
 				}
 				const int channels = input.getChannels();
@@ -403,7 +403,7 @@ struct TeleportInModuleWidget : TeleportModuleWidget {
 					}
 				}
 				if (! foundLabel) {
-					inModule->setPortLabel(i, string::f("Port %d", i));
+					inModule->setPortLabel(i, string::f("Port %d not connected", i));
 				}
 			}
 		}

--- a/src/Teleport.hpp
+++ b/src/Teleport.hpp
@@ -22,6 +22,10 @@ struct Teleport : Module {
 	inline bool sourceExists(std::string lbl) {
 		return sources.find(lbl) != sources.end();
 	}
+
+	inline void setPortLabel(int portNum, std::string label) {
+		configInput(portNum, label);
+	}
 };
 
 std::map<std::string, TeleportInModule*> Teleport::sources = {};

--- a/src/Teleport.hpp
+++ b/src/Teleport.hpp
@@ -8,6 +8,8 @@ struct TeleportInModule;
 
 struct Teleport : Module {
 	std::string label;
+	float portConfigTime = 0.f;
+	PortWidget *portWidgets[NUM_TELEPORT_INPUTS];
 	Teleport(int numParams, int numInputs, int numOutputs, int numLights = 0) {
 		config(numParams, numInputs, numOutputs, numLights);
 	}
@@ -25,6 +27,10 @@ struct Teleport : Module {
 
 	inline void setPortLabel(int portNum, std::string label) {
 		configInput(portNum, label);
+	}
+
+	inline void setPortWidget(int portNum, PortWidget *widget) {
+		portWidgets[portNum] = widget;
 	}
 };
 

--- a/src/Teleport.hpp
+++ b/src/Teleport.hpp
@@ -25,10 +25,6 @@ struct Teleport : Module {
 		return sources.find(lbl) != sources.end();
 	}
 
-	inline void setPortLabel(int portNum, std::string label) {
-		configInput(portNum, label);
-	}
-
 	inline void setPortWidget(int portNum, PortWidget *widget) {
 		portWidgets[portNum] = widget;
 	}


### PR DESCRIPTION
Hi there! I'd like to make the suggestion that teleport should mirror the source port names to the mirrored location. That way I can hover my mouse over the output ports on the TeleportOut module to see what the source port name is. I've got a first pass on the code here, and I think I've got rid of all the obvious segfaults, but its not battle tested yet. I added some code to slow down the update, `configOutput` seems like a heavy process, so its only performed every 1s.