### PR TITLE
Teleport: mirror port labels, attempt 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for Little Utils
 
+## v2.1.0 (unreleased)
+
+Mouse-overing on the outputs of Teleport Out now show which device and port the signal is coming from on the input side (thanks @EnigmaCurry for the feature suggestion and initial implementation).
+
 ## v2.0.0 (2021-12-23)
 
 Port to Rack v2. Thi includes new v2 API features, such as input/output labels and improved labels for switches.

--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -321,17 +321,40 @@ struct TeleportSourceSelectorTextBox : HoverableTextBox, TeleportLabelDisplay {
 };
 
 // Custom PortWidget for teleport outputs, with custom tooltip behavior
-struct TeleportOutPortTooltip;
+struct TeleportOutPortWidget;
+
+struct TeleportOutPortTooltip : ui::Tooltip {
+	TeleportOutPortWidget* portWidget;
+
+	void step() override {
+		printf("TeleportOutPortTooltip::step()\n");
+	}
+};
 
 struct TeleportOutPortWidget : PJ301MPort {
-	TeleportOutPortTooltip* customTooltip;
+	TeleportOutPortTooltip* customTooltip = NULL;
 
 	void createTooltip() {
-		printf("TeleportOutPortWidget::createTooltip()\n");
+		// same as PortWidget::craeteTooltip(), but internal->tooltip replaced with customTooltip
+		if (!settings::tooltips)
+			return;
+		if (customTooltip)
+			return;
+		if (!module)
+			return;
+
+		TeleportOutPortTooltip* tooltip = new TeleportOutPortTooltip;
+		tooltip->portWidget = this;
+		APP->scene->addChild(tooltip);
+		customTooltip = tooltip;
 	}
 
 	void destroyTooltip() {
-		printf("TeleportOutPortWidget::destroyTooltip()\n");
+		if(!customTooltip)
+			return;
+		APP->scene->removeChild(customTooltip);
+		delete customTooltip;
+		customTooltip = NULL;
 	}
 
 	// createTooltip cannot be overridden, so we have to manually reimplement all the methods that call createTooltip, because these can be overridden.
@@ -373,9 +396,6 @@ struct TeleportOutPortWidget : PJ301MPort {
 		destroyTooltip();
 	}
 
-};
-
-struct TeleportOutPortTooltip : ui::Tooltip {
 };
 
 

--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -347,7 +347,8 @@ struct TeleportOutPortWidget : PJ301MPort {
 		customTooltip = NULL;
 	}
 
-	// createTooltip cannot be overridden, so we have to manually reimplement all the methods that call createTooltip, because these can be overridden.
+	// createTooltip cannot be overridden, so we have to manually override and
+	// reimplement all the methods that call createTooltip.
 	void onEnter(const EnterEvent& e) override {
 		createTooltip();
 		// don't call superclass onEnter, it calls its own createTooltip()
@@ -363,6 +364,9 @@ struct TeleportOutPortWidget : PJ301MPort {
 			createTooltip();
 		}
 		DragDropEvent e2 = e;
+		// HACK: this depends on the implementation detail that the superclass
+		// onDragDrop will call createTooltip() if the origin is not null. Same
+		// for onDragEnter.
 		e2.origin = NULL;
 		PJ301MPort::onDragDrop(e2);
 	}
@@ -475,7 +479,6 @@ void TeleportOutPortTooltip::step() {
 		// Assemble the final tooltip text.
 		text = labelText;
 
-		// Description
 		if(description != "") {
 			text += "\n";
 			text += description;
@@ -487,7 +490,7 @@ void TeleportOutPortTooltip::step() {
 		}
 
 		if(cableText != "") {
-			// cableText starts with newline;
+			// cableText already starts with newline
 			text += cableText;
 		}
 

--- a/src/Teleport.cpp
+++ b/src/Teleport.cpp
@@ -321,16 +321,6 @@ struct TeleportSourceSelectorTextBox : HoverableTextBox, TeleportLabelDisplay {
 };
 
 // Custom PortWidget for teleport outputs, with custom tooltip behavior
-struct TeleportOutPortWidget;
-
-struct TeleportOutPortTooltip : ui::Tooltip {
-	TeleportOutPortWidget* portWidget;
-
-	void step() override {
-		printf("TeleportOutPortTooltip::step()\n");
-	}
-};
-
 struct TeleportOutPortWidget : PJ301MPort {
 	TeleportOutPortTooltip* customTooltip = NULL;
 
@@ -397,6 +387,11 @@ struct TeleportOutPortWidget : PJ301MPort {
 	}
 
 };
+
+void TeleportOutPortTooltip::step() {
+	printf("TeleportOutPortTooltip::step()\n");
+};
+
 
 
 

--- a/src/Teleport.hpp
+++ b/src/Teleport.hpp
@@ -24,5 +24,14 @@ struct Teleport : Module {
 	}
 };
 
+
+// these have to be forward-declared here to make the implementation of step() possible, see cpp for details
+struct TeleportOutPortWidget;
+struct TeleportOutPortTooltip : ui::Tooltip {
+	TeleportOutPortWidget* portWidget;
+	void step() override;
+};
+
+
 std::map<std::string, TeleportInModule*> Teleport::sources = {};
 std::string Teleport::lastInsertedKey = "";


### PR DESCRIPTION
On mouse-over, the teleport output label will show the label of the connected port on the other end.

This is an alternative to #11 and #12. Compared to those, this implementation overrides the port label tooltip implementation instead of messing with the port label. This is cleaner, avoids problems with looping, and ensures that the displayed label is always up to date, even if the source port has a dynamically updated label.